### PR TITLE
feat(Challenges/24) adds modes to PerlinNoiseFlowField

### DIFF
--- a/Challenges/24-PerlinNoiseFlowField/particle.js
+++ b/Challenges/24-PerlinNoiseFlowField/particle.js
@@ -18,9 +18,7 @@ function Particle() {
 		this.acc.add(force);
 	}
 
-	this.show = function(col = color(0, 5)) {
-		stroke(col);
-		strokeWeight(1);
+	this.show = function() {
 		line(this.pos.x, this.pos.y, this.prevPos.x, this.prevPos.y);
 	}
 

--- a/Challenges/24-PerlinNoiseFlowField/sketch.js
+++ b/Challenges/24-PerlinNoiseFlowField/sketch.js
@@ -6,12 +6,18 @@ var fr;
 var zOff;
 
 var particles = [];
-
 var flowField = [];
+
+var hu;
+var hueShift;
+var drawType = 1;
+var fade = 0;
+var fadeIn = 0.005;
 
 function setup(){
 	createCanvas(windowWidth, windowHeight);
 	fr = createP('');
+	colorMode(HSB);
 	reset();
 }
 
@@ -21,15 +27,24 @@ function reset(){
 	scl = 10;
 	cols = floor(width / scl);
 	rows = floor(height / scl);
+	hu = 0;
+	hueShift = 1;
 
 	flowField = new Array(cols * rows);
-	for (let i = 0; i < 10000; i++) {
+	for (let i = 0; i < 15000; i++) {
 		particles[i] = new Particle();
 	}
-	background(255);
+	if (drawType === 2){
+		background(0);
+	} else if (drawType === 5){
+		background(360);
+	}
 }
 
 function draw(){
+	if (drawType === 1) {
+		background((hu+240) % 359, 359, 7);
+	}
 	let yOff = 0;
 	for (let y = 0; y < rows; y++) {
 		let xOff = 0;
@@ -46,14 +61,75 @@ function draw(){
 	for (let i = 0; i < particles.length; i++) {
 		const p = particles[i];
 		p.follow(flowField);
+		if (drawType === 1 || drawType === 2) {
+			let pHue = hu;
+			pHue += map(i, 0, particles.length, 0, 120);
+			if (pHue > 359) pHue %= 359;
+			stroke(pHue, 100, 75, 50);
+		} else if (drawType === 4) {
+			let pHue = hu;
+			pHue += map(i, 0, particles.length, 0, 10);
+			if (pHue > 100) pHue %= 100;
+			stroke(0, 0, pHue, 5);
+		} else if (drawType === 5) {
+			stroke(0, 0, 0, 0.01);
+		}
 		p.show();
 		p.update();
 	}
 	fr.html(floor(frameRate()));
 	zOff+=0.01;
+	shiftHue();
+}
+
+function shiftHue() {
+	hu += hueShift;
+	if (hu > 359) hu = 0;
 }
 
 function windowResized() {
   resizeCanvas(windowWidth, windowHeight);
 	reset();
+}
+
+function keyPressed() {
+	console.log(key);
+	
+	if (key === '1') { // rainbow on black
+		drawType = 1;
+	} else if (key === '2') { // rainbow
+		drawType = 2;
+	} else if (key === '3') { // retains color,  will fill the screen over time.
+		drawType = 3;
+	} else if (key === '4') { // greyScale 
+		drawType = 4;
+	} else if (key === '5') { // example, draws faint black lines on white, will fill the screen with black over time.
+		background(360);
+		drawType = 5;
+	} else if (['a', 'ArrowLeft'].includes(key)) {
+		updateDrawType(-1);
+	} else if (['d', 'ArrowRight', ' '].includes(key)) {
+		updateDrawType(1);
+	}
+}
+
+function mouseClicked() {
+	if (mouseButton == LEFT) {
+		updateDrawType(1);
+	}
+}
+
+function updateDrawType(dir) {
+	drawType += dir;
+	if (drawType === 5) {
+		background(360);
+	}
+	if (drawType > 5) {
+		drawType = 1;
+		return;
+	}
+	if (drawType < 1) {
+		background(360);
+		drawType = 5;
+	}
 }


### PR DESCRIPTION
- [x] adds modes
	- [x] Rainbow on black
	- [x] Rainbow
	- [x] Color retention (stays with last assigned color, will fill screen)
	- [x] greyScale (goes from black to white then immediately back to black)
	- [x] based on the example, I call it hair mode. It draws faint black lines on a white background (will fill screen)
- [x] adds mode switch tools
	- [x] switch using keypress
		- [x] a/LeftArrow goes back one mode
		- [x] b/RightArrow/Space goes forward one mode
	- [x] switch using mouse, left click goes forward

Initializes Issue-#